### PR TITLE
Add an erase_prefix method

### DIFF
--- a/src/htrie_hash.h
+++ b/src/htrie_hash.h
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -1440,7 +1441,7 @@ private:
         auto it = hnode.array_hash().begin();
         while(it != hnode.array_hash().end()) {
             if(it.key_size() >= prefix_size && 
-               std::equal(prefix, prefix + prefix_size, it.key()))
+               std::memcmp(prefix, it.key(), prefix_size * sizeof(CharT)) == 0)
             {
                 it = hnode.array_hash().erase(it);
                 ++nb_erased;

--- a/src/htrie_map.h
+++ b/src/htrie_map.h
@@ -249,6 +249,25 @@ public:
     
     
     
+#ifdef TSL_HAS_STRING_VIEW
+    size_type erase_prefix(const std::basic_string_view<CharT>& prefix) {
+        return m_ht.erase_prefix(prefix.data(), prefix.size());
+    }
+#else
+    size_type erase_prefix(const CharT* prefix) {
+        return m_ht.erase_prefix(prefix, std::strlen(prefix));
+    }
+    
+    size_type erase_prefix(const std::basic_string<CharT>& prefix) {
+        return m_ht.erase_prefix(prefix.data(), prefix.size());
+    }
+#endif
+    size_type erase_prefix_ks(const CharT* prefix, size_type prefix_size) {
+        return m_ht.erase_prefix(prefix, prefix_size);
+    }
+    
+    
+    
     void swap(htrie_map& other) { other.m_ht.swap(m_ht); }
     
     /*

--- a/src/htrie_set.h
+++ b/src/htrie_set.h
@@ -222,6 +222,25 @@ public:
     
     
     
+#ifdef TSL_HAS_STRING_VIEW
+    size_type erase_prefix(const std::basic_string_view<CharT>& prefix) {
+        return m_ht.erase_prefix(prefix.data(), prefix.size());
+    }
+#else
+    size_type erase_prefix(const CharT* prefix) {
+        return m_ht.erase_prefix(prefix, std::strlen(prefix));
+    }
+    
+    size_type erase_prefix(const std::basic_string<CharT>& prefix) {
+        return m_ht.erase_prefix(prefix.data(), prefix.size());
+    }
+#endif
+    size_type erase_prefix_ks(const CharT* prefix, size_type prefix_size) {
+        return m_ht.erase_prefix(prefix, prefix_size);
+    }
+    
+    
+    
     void swap(htrie_set& other) { other.m_ht.swap(m_ht); }
     
     

--- a/tests/trie_map_tests.cpp
+++ b/tests/trie_map_tests.cpp
@@ -257,6 +257,65 @@ BOOST_AUTO_TEST_CASE(test_equal_prefix_range) {
 }
 
 /**
+ * erase_prefix
+ */
+BOOST_AUTO_TEST_CASE(test_erase_prefix) {
+    tsl::htrie_map<char, int64_t> map = utils::get_filled_map<tsl::htrie_map<char, int64_t>>(10000, 200);
+    
+    BOOST_CHECK_EQUAL(map.erase_prefix("Key 1"), 1111);
+    BOOST_CHECK_EQUAL(map.size(), 8889);
+    
+    BOOST_CHECK_EQUAL(map.erase_prefix("Key 22"), 111);
+    BOOST_CHECK_EQUAL(map.size(), 8778);
+    
+    BOOST_CHECK_EQUAL(map.erase_prefix("Key 333"), 11);
+    BOOST_CHECK_EQUAL(map.size(), 8767);
+    
+    BOOST_CHECK_EQUAL(map.erase_prefix("Key 4444"), 1);
+    BOOST_CHECK_EQUAL(map.size(), 8766);
+    
+    BOOST_CHECK_EQUAL(map.erase_prefix("Key 55555"), 0);
+    BOOST_CHECK_EQUAL(map.size(), 8766);
+    
+    for(auto it = map.begin(); it != map.end(); ++it) {
+        BOOST_CHECK(it.key().find("Key 1") == std::string::npos);
+        BOOST_CHECK(it.key().find("Key 22") == std::string::npos);
+        BOOST_CHECK(it.key().find("Key 333") == std::string::npos);
+        BOOST_CHECK(it.key().find("Key 4444") == std::string::npos);
+    }
+    
+    BOOST_CHECK_EQUAL(std::distance(map.begin(), map.end()), map.size());
+}
+
+BOOST_AUTO_TEST_CASE(test_erase_prefix_all_1) {
+    tsl::htrie_map<char, int64_t> map = utils::get_filled_map<tsl::htrie_map<char, int64_t>>(1000, 8);
+    BOOST_CHECK_EQUAL(map.size(), 1000);
+    BOOST_CHECK_EQUAL(map.erase_prefix(""), 1000);
+    BOOST_CHECK_EQUAL(map.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_erase_prefix_all_2) {
+    tsl::htrie_map<char, int64_t> map = utils::get_filled_map<tsl::htrie_map<char, int64_t>>(1000, 8);
+    BOOST_CHECK_EQUAL(map.size(), 1000);
+    BOOST_CHECK_EQUAL(map.erase_prefix("Ke"), 1000);
+    BOOST_CHECK_EQUAL(map.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_erase_prefix_none) {
+    tsl::htrie_map<char, int64_t> map = utils::get_filled_map<tsl::htrie_map<char, int64_t>>(1000, 8);
+    BOOST_CHECK_EQUAL(map.erase_prefix("Kea"), 0);
+    BOOST_CHECK_EQUAL(map.size(), 1000);
+}
+
+BOOST_AUTO_TEST_CASE(test_erase_prefix_empty_map) {
+    tsl::htrie_map<char, int64_t> map;
+    BOOST_CHECK_EQUAL(map.erase_prefix("Kea"), 0);
+    BOOST_CHECK_EQUAL(map.erase_prefix(""), 0);
+}
+
+
+
+/**
  * operator== and operator!=
  */
 BOOST_AUTO_TEST_CASE(test_compare) {


### PR DESCRIPTION
Add an `erase_prefix` method to erase all the keys having a specific prefix.