### PR TITLE
 Add longest_prefix method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ The library provides two classes: `tsl::htrie_map` and `tsl::htrie_set`.
 
 - Header-only library, just include the project to your include path and you are ready to go.
 - Low memory usage while keeping reasonable performances (see [benchmark](https://github.com/Tessil/hat-trie#benchmark)).
-- Allow prefix searches through `equal_prefix_range` (usefull for autocompletion for example).
+- Support prefix searches through `equal_prefix_range` (usefull for autocompletion for example) and prefix erasures through `erase_prefix`.
+- Support longest matching prefix searches through `longest_prefix`.
 - Keys are not ordered as they are partially stored in a hash map.
 - All operations modifying the data structure (insert, emplace, erase, ...) invalidate the iterators. 
 - Support null characters in the key (you can thus store binary data in the trie).
 - Support for any type of value as long at it's either copy-constructible or both nothrow move constructible and nothrow move assignable.
 - The balance between speed and memory usage can be modified through the `max_load_factor` method. A lower max load factor will increase the speed, a higher one will reduce the memory usage. Its default value is set to 8.0.
-- The default burst threshold, which is the maximum size of an array hash node before a burst occurs, is set to 16 384 which provides good performances for exact searches. If you mainly use prefix searches, you may want to reduce it to something like 4096 or lower for faster iteration on the results through the `burst_threshold` method.
+- The default burst threshold, which is the maximum size of an array hash node before a burst occurs, is set to 16 384 which provides good performances for exact searches. If you mainly use prefix searches, you may want to reduce it to something like 1024 or lower for faster iteration on the results through the `burst_threshold` method.
 - By default the maximum allowed size for a key is set to 65 535. This can be raised through the `KeySizeT` template parameter.
 
 Thread-safety and exception guarantees are similar to the STL containers.
@@ -218,6 +219,7 @@ make
 The API can be found [here](https://tessil.github.io/hat-trie/doc_without_string_view/html). If `std::string_view` is available, the API changes slightly and can be found [here](https://tessil.github.io/hat-trie/doc/html/).
 
 ### Example
+
 ```c++
 #include <iostream>
 #include <string>
@@ -275,6 +277,12 @@ int main() {
         std::cout << "{" << it.key() << ", " << *it << "}" << std::endl;
     }
     
+    // Find longest match prefix.
+    auto longest_prefix = map2.longest_prefix("apple juice");
+    if(longest_prefix != map2.end()) {
+        // {apple, 1}
+        std::cout << longest_prefix.key() << std::endl;
+    }
     
     // Prefix erase
     map2.erase_prefix("ma");

--- a/tests/trie_map_tests.cpp
+++ b/tests/trie_map_tests.cpp
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(test_longest_prefix) {
     tsl::htrie_map<char, int> map;
     map.burst_threshold(4);
     map = {{"a", 1}, {"aa", 1}, {"aaa", 1}, {"aaaaa", 1}, {"aaaaaa", 1}, {"aaaaaaa", 1},
-           {"ab", 1}, {"abcd", 1}, {"babc", 1}};
+           {"ab", 1}, {"abcde", 1}, {"abcdf", 1}, {"abcdg", 1}, {"abcdh", 1}, {"babc", 1}};
     
     BOOST_CHECK_EQUAL(map.longest_prefix("a").key(), "a");
     BOOST_CHECK_EQUAL(map.longest_prefix("aa").key(), "aa");
@@ -324,13 +324,21 @@ BOOST_AUTO_TEST_CASE(test_longest_prefix) {
     BOOST_CHECK_EQUAL(map.longest_prefix("aaaa").key(), "aaa");
     BOOST_CHECK_EQUAL(map.longest_prefix("ab").key(), "ab");
     BOOST_CHECK_EQUAL(map.longest_prefix("abc").key(), "ab");
-    BOOST_CHECK_EQUAL(map.longest_prefix("abcd").key(), "abcd");
-    BOOST_CHECK_EQUAL(map.longest_prefix("abcde").key(), "abcd");
+    BOOST_CHECK_EQUAL(map.longest_prefix("abcd").key(), "ab");
+    BOOST_CHECK_EQUAL(map.longest_prefix("abcdz").key(), "ab");
+    BOOST_CHECK_EQUAL(map.longest_prefix("abcde").key(), "abcde");
+    BOOST_CHECK_EQUAL(map.longest_prefix("abcdef").key(), "abcde");
+    BOOST_CHECK_EQUAL(map.longest_prefix("abcdefg").key(), "abcde");
     BOOST_CHECK(map.longest_prefix("dabc") == map.end());
     BOOST_CHECK(map.longest_prefix("b") == map.end());
     BOOST_CHECK(map.longest_prefix("bab") == map.end());
     BOOST_CHECK(map.longest_prefix("babd") == map.end());
     BOOST_CHECK(map.longest_prefix("") == map.end());
+    
+    map.insert("", 1);
+    BOOST_CHECK_EQUAL(map.longest_prefix("dabc").key(), "");
+    BOOST_CHECK_EQUAL(map.longest_prefix("").key(), "");
+    
 }
 
 /**

--- a/tests/trie_map_tests.cpp
+++ b/tests/trie_map_tests.cpp
@@ -310,6 +310,30 @@ BOOST_AUTO_TEST_CASE(test_equal_prefix_range_empty) {
 }
 
 /**
+ * longest_prefix
+ */
+BOOST_AUTO_TEST_CASE(test_longest_prefix) {
+    tsl::htrie_map<char, int> map;
+    map.burst_threshold(4);
+    map = {{"a", 1}, {"aa", 1}, {"aaa", 1}, {"aaaaa", 1}, {"aaaaaa", 1}, {"aaaaaaa", 1},
+           {"ab", 1}, {"abcd", 1}, {"babc", 1}};
+    
+    BOOST_CHECK_EQUAL(map.longest_prefix("a").key(), "a");
+    BOOST_CHECK_EQUAL(map.longest_prefix("aa").key(), "aa");
+    BOOST_CHECK_EQUAL(map.longest_prefix("aaa").key(), "aaa");
+    BOOST_CHECK_EQUAL(map.longest_prefix("aaaa").key(), "aaa");
+    BOOST_CHECK_EQUAL(map.longest_prefix("ab").key(), "ab");
+    BOOST_CHECK_EQUAL(map.longest_prefix("abc").key(), "ab");
+    BOOST_CHECK_EQUAL(map.longest_prefix("abcd").key(), "abcd");
+    BOOST_CHECK_EQUAL(map.longest_prefix("abcde").key(), "abcd");
+    BOOST_CHECK(map.longest_prefix("dabc") == map.end());
+    BOOST_CHECK(map.longest_prefix("b") == map.end());
+    BOOST_CHECK(map.longest_prefix("bab") == map.end());
+    BOOST_CHECK(map.longest_prefix("babd") == map.end());
+    BOOST_CHECK(map.longest_prefix("") == map.end());
+}
+
+/**
  * erase_prefix
  */
 BOOST_AUTO_TEST_CASE(test_erase_prefix) {
@@ -589,8 +613,12 @@ BOOST_AUTO_TEST_CASE(test_empty_map) {
     auto range_prefix = map.equal_prefix_range("test");
     BOOST_CHECK(range_prefix.first == range_prefix.second);
     
+    BOOST_CHECK(map.longest_prefix("test") == map.end());
+    
     BOOST_CHECK_EQUAL(map.erase("test"), 0);
     BOOST_CHECK(map.erase(map.begin(), map.end()) == map.end());
+    
+    BOOST_CHECK_EQUAL(map.erase_prefix("test"), 0);
     
     BOOST_CHECK_EQUAL(map["new value"], int{});
 }

--- a/tsl/htrie_hash.h
+++ b/tsl/htrie_hash.h
@@ -1486,13 +1486,18 @@ private:
                                        const CharT* value, size_type value_size) const 
     {
         const anode* current_node = &search_start_node;
+        const_iterator longest_found_prefix = cend();
         
         for(size_type ivalue = 0; ivalue < value_size; ivalue++) {
             if(current_node->is_trie_node()) {
                 const trie_node& tnode = current_node->as_trie_node();
                 
+                if(tnode.val_node() != nullptr) {
+                    longest_found_prefix = const_iterator(tnode);
+                }
+                
                 if(tnode.child(value[ivalue]) == nullptr) {
-                    return cend();
+                    return longest_found_prefix;
                 }
                 else {
                     current_node = tnode.child(value[ivalue]).get();
@@ -1513,22 +1518,27 @@ private:
                     }
                 }
                 
-                return cend();
+                return longest_found_prefix;
             }
         }
         
         if(current_node->is_trie_node()) {
             const trie_node& tnode = current_node->as_trie_node();
+            
             if(tnode.val_node() != nullptr) {
-                return const_iterator(tnode);
-            }
-            else {
-                return cend();
+                longest_found_prefix = const_iterator(tnode);
             }
         }
         else {
-            return find_in_hash_node(current_node->as_hash_node(), "", 0);
+            const hash_node& hnode = current_node->as_hash_node();
+            
+            auto it = hnode.array_hash().find_ks("", 0);
+            if(it != hnode.array_hash().end()) {
+                longest_found_prefix = const_iterator(hnode, it);
+            }
         }
+        
+        return longest_found_prefix;
     }
     
     

--- a/tsl/htrie_hash.h
+++ b/tsl/htrie_hash.h
@@ -1126,6 +1126,22 @@ public:
         return equal_prefix_range_impl(*m_root, prefix, prefix_size);
     }
     
+    iterator longest_prefix(const CharT* key, size_type key_size) {
+        if(m_root == nullptr) {
+            return end();
+        }
+        
+        return longest_prefix_impl(*m_root, key, key_size);
+    }
+    
+    const_iterator longest_prefix(const CharT* key, size_type key_size) const {
+        if(m_root == nullptr) {
+            return cend();
+        }
+        
+        return longest_prefix_impl(*m_root, key, key_size);
+    }
+    
     
     /*
      * Hash policy 
@@ -1458,7 +1474,62 @@ private:
         }
     }
     
+
+    iterator longest_prefix_impl(const anode& search_start_node,
+                                 const CharT* value, size_type value_size)
+    {
+        return mutable_iterator(static_cast<const htrie_hash*>(this)->longest_prefix_impl(search_start_node, 
+                                                                                          value, value_size));
+    }
     
+    const_iterator longest_prefix_impl(const anode& search_start_node,
+                                       const CharT* value, size_type value_size) const 
+    {
+        const anode* current_node = &search_start_node;
+        
+        for(size_type ivalue = 0; ivalue < value_size; ivalue++) {
+            if(current_node->is_trie_node()) {
+                const trie_node& tnode = current_node->as_trie_node();
+                
+                if(tnode.child(value[ivalue]) == nullptr) {
+                    return cend();
+                }
+                else {
+                    current_node = tnode.child(value[ivalue]).get();
+                }
+            }
+            else {
+                const hash_node& hnode = current_node->as_hash_node();
+                
+                /**
+                 * Test the presence in the hash node of each substring from the 
+                 * remaining [ivalue, value_size) string starting from the longest. 
+                 * Also test the empty string.
+                 */
+                for(std::size_t i = ivalue; i <= value_size; i++) {
+                    auto it = hnode.array_hash().find_ks(value + ivalue, (value_size - i));
+                    if(it != hnode.array_hash().end()) {
+                        return const_iterator(hnode, it);
+                    }
+                }
+                
+                return cend();
+            }
+        }
+        
+        if(current_node->is_trie_node()) {
+            const trie_node& tnode = current_node->as_trie_node();
+            if(tnode.val_node() != nullptr) {
+                return const_iterator(tnode);
+            }
+            else {
+                return cend();
+            }
+        }
+        else {
+            return find_in_hash_node(current_node->as_hash_node(), "", 0);
+        }
+    }
     
     
     std::pair<prefix_iterator, prefix_iterator> equal_prefix_range_impl(

--- a/tsl/htrie_map.h
+++ b/tsl/htrie_map.h
@@ -453,7 +453,78 @@ public:
         return m_ht.equal_prefix_range(prefix.data(), prefix.size());
     }
 #endif
-
+    
+    
+    
+    /**
+     * Return the element in the trie which is the longest prefix of `key`. If no
+     * element in the trie is a prefix of `key`, the end iterator is returned.
+     * 
+     * Example: 
+     * 
+     *     tsl::htrie_map<char, int> map = {{"/foo", 1}, {"/foo/bar", 1}};
+     *     
+     *     map.longest_prefix("/foo"); // returns {"/foo", 1} 
+     *     map.longest_prefix("/foo/baz"); // returns {"/foo", 1} 
+     *     map.longest_prefix("/foo/bar/baz"); // returns {"/foo/bar", 1} 
+     *     map.longest_prefix("/foo/bar/"); // returns {"/foo/bar", 1} 
+     *     map.longest_prefix("/bar"); // returns end() 
+     *     map.longest_prefix(""); // returns end() 
+     */
+    iterator longest_prefix_ks(const CharT* key, size_type key_size) {
+        return m_ht.longest_prefix(key, key_size);
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    const_iterator longest_prefix_ks(const CharT* key, size_type key_size) const {
+        return m_ht.longest_prefix(key, key_size);
+    }
+#ifdef TSL_HAS_STRING_VIEW 
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    iterator longest_prefix(const std::basic_string_view<CharT>& key) {
+        return m_ht.longest_prefix(key.data(), key.size());
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    const_iterator longest_prefix(const std::basic_string_view<CharT>& key) const {
+        return m_ht.longest_prefix(key.data(), key.size());
+    }
+#else
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    iterator longest_prefix(const CharT* key) {
+        return m_ht.longest_prefix(key, std::strlen(key));
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    const_iterator longest_prefix(const CharT* key) const {
+        return m_ht.longest_prefix(key, std::strlen(key));
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    iterator longest_prefix(const std::basic_string<CharT>& key) {
+        return m_ht.longest_prefix(key.data(), key.size());
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    const_iterator longest_prefix(const std::basic_string<CharT>& key) const {
+        return m_ht.longest_prefix(key.data(), key.size());
+    }
+#endif 
+    
     
     
     /*

--- a/tsl/htrie_set.h
+++ b/tsl/htrie_set.h
@@ -412,7 +412,7 @@ public:
      * 
      * Example:
      * 
-     *     tsl::htrie_setp<char> map = {"/foo", "/foo/bar"};
+     *     tsl::htrie_set<char> map = {"/foo", "/foo/bar"};
      * 
      *     map.longest_prefix("/foo"); // returns "/foo"
      *     map.longest_prefix("/foo/baz"); // returns "/foo"

--- a/tsl/htrie_set.h
+++ b/tsl/htrie_set.h
@@ -406,6 +406,77 @@ public:
     
     
     
+    /**
+     * Return the element in the trie which is the longest prefix of `key`. If no
+     * element in the trie is a prefix of `key`, the end iterator is returned.
+     * 
+     * Example:
+     * 
+     *     tsl::htrie_setp<char> map = {"/foo", "/foo/bar"};
+     * 
+     *     map.longest_prefix("/foo"); // returns "/foo"
+     *     map.longest_prefix("/foo/baz"); // returns "/foo"
+     *     map.longest_prefix("/foo/bar/baz"); // returns "/foo/bar"
+     *     map.longest_prefix("/foo/bar/"); // returns "/foo/bar"
+     *     map.longest_prefix("/bar"); // returns end()
+     *     map.longest_prefix(""); // returns end()
+     */
+    iterator longest_prefix_ks(const CharT* key, size_type key_size) {
+        return m_ht.longest_prefix(key, key_size);
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    const_iterator longest_prefix_ks(const CharT* key, size_type key_size) const {
+        return m_ht.longest_prefix(key, key_size);
+    }
+#ifdef TSL_HAS_STRING_VIEW 
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    iterator longest_prefix(const std::basic_string_view<CharT>& key) {
+        return m_ht.longest_prefix(key.data(), key.size());
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    const_iterator longest_prefix(const std::basic_string_view<CharT>& key) const {
+        return m_ht.longest_prefix(key.data(), key.size());
+    }
+#else
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    iterator longest_prefix(const CharT* key) {
+        return m_ht.longest_prefix(key, std::strlen(key));
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    const_iterator longest_prefix(const CharT* key) const {
+        return m_ht.longest_prefix(key, std::strlen(key));
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    iterator longest_prefix(const std::basic_string<CharT>& key) {
+        return m_ht.longest_prefix(key.data(), key.size());
+    }
+    
+    /**
+     * @copydoc longest_prefix_ks(const CharT* key, size_type key_size)
+     */
+    const_iterator longest_prefix(const std::basic_string<CharT>& key) const {
+        return m_ht.longest_prefix(key.data(), key.size());
+    }
+#endif    
+    
+    
+    
     /*
      *  Hash policy 
      */


### PR DESCRIPTION
Add a `longest_prefix` method to find the key in the trie which is the longest prefix of a given value (#13).

```c++
tsl::htrie_set<char> map = {"/foo", "/foo/bar"};

map.longest_prefix("/foo"); // returns "/foo"
map.longest_prefix("/foo/baz"); // returns "/foo"
map.longest_prefix("/foo/bar/baz"); // returns "/foo/bar"
map.longest_prefix("/foo/bar/"); // returns "/foo/bar"
map.longest_prefix("/bar"); // returns end()
map.longest_prefix(""); // returns end()
```