### PR TITLE
Add support for efficient serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ To do so, it requires the user to provide a function object for both serializati
 ```c++
 struct serializer {
     // Must support the following types for U: std::uint64_t, float and T if a map is used.
+    template<typename U>
     void operator()(const U& value);
     void operator()(const CharT* value, std::size_t value_size);
 };
@@ -320,6 +321,7 @@ struct serializer {
 ```c++
 struct deserializer {
     // Must support the following types for U: std::uint64_t, float and T if a map is used.
+    template<typename U>
     U operator()();
     void operator()(CharT* value_out, std::size_t value_size);
 };

--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ It's a well adapted structure to store a large number of strings.
   <img src="https://tessil.github.io/images/hat-trie.png" width="600px" />
 </p>
 
-For the àrray hash part, the [array-hash](https://github.com/Tessil/array-hash) project is used and included in the repository.
+For the array hash part, the [array-hash](https://github.com/Tessil/array-hash) project is used and included in the repository.
 
 The library provides two classes: `tsl::htrie_map` and `tsl::htrie_set`.
 
 ### Overview
 
 - Header-only library, just add the [include](include/) directory to your include path and you are ready to go. If you use CMake, you can also use the `tsl::hat_trie` exported target from the [CMakeLists.txt](CMakeLists.txt).
-- Low memory usage while keeping reasonable performances (see [benchmark](https://github.com/Tessil/hat-trie#benchmark)).
+- Low memory usage while keeping reasonable performances (see [benchmark](#benchmark)).
 - Support prefix searches through `equal_prefix_range` (usefull for autocompletion for example) and prefix erasures through `erase_prefix`.
 - Support longest matching prefix searches through `longest_prefix`.
+- Support for efficient serialization and deserialization (see [example](#serialization) and the `serialize/deserialize` methods in the [API](https://tessil.github.io/hat-trie/doc/html/classtsl_1_1htrie__map.html) for details).
 - Keys are not ordered as they are partially stored in a hash map.
 - All operations modifying the data structure (insert, emplace, erase, ...) invalidate the iterators. 
 - Support null characters in the key (you can thus store binary data in the trie).
@@ -303,6 +304,225 @@ int main() {
 } 
 ```
 
+#### Serialization
+
+The library provides an efficient way to serialize and deserialize a map or a set so that it can be saved to a file or send through the network.
+To do so, it requires the user to provide a function object for both serialization and deserialization.
+
+```c++
+struct serializer {
+    // Must support the following types for U: std::uint64_t, float and T if a map is used.
+    void operator()(const U& value);
+    void operator()(const CharT* value, std::size_t value_size);
+};
+```
+
+```c++
+struct deserializer {
+    // Must support the following types for U: std::uint64_t, float and T if a map is used.
+    U operator()();
+    void operator()(CharT* value_out, std::size_t value_size);
+};
+```
+
+Note that the implementation leaves binary compatibilty (endianness, float binary representation, size of int, ...) of the types it serializes/deserializes in the hands of the provided function objects if compatibilty is required.
+
+More details regarding the `serialize` and `deserialize` methods can be found in the [API](https://tessil.github.io/hat-trie/doc/html/classtsl_1_1htrie__map.html).
+
+```c++
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <type_traits>
+#include <tsl/htrie_map.h>
+
+
+class serializer {
+public:
+    serializer(const char* file_name) {
+        m_ostream.exceptions(m_ostream.badbit | m_ostream.failbit);
+        m_ostream.open(file_name);
+    }
+    
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    void operator()(const T& value) {
+        m_ostream.write(reinterpret_cast<const char*>(&value), sizeof(T));
+    }
+    
+    void operator()(const char* value, std::size_t value_size) {
+        m_ostream.write(value, value_size);
+    }
+
+private:
+    std::ofstream m_ostream;
+};
+
+class deserializer {
+public:
+    deserializer(const char* file_name) {
+        m_istream.exceptions(m_istream.badbit | m_istream.failbit | m_istream.eofbit);
+        m_istream.open(file_name);
+    }
+    
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    T operator()() {
+        T value;
+        m_istream.read(reinterpret_cast<char*>(&value), sizeof(T));
+        
+        return value;
+    }
+    
+    void operator()(char* value_out, std::size_t value_size) {
+        m_istream.read(value_out, value_size);
+    }
+
+private:
+    std::ifstream m_istream;
+};
+
+
+int main() {
+    const tsl::htrie_map<char, std::int64_t> map = {{"one", 1}, {"two", 2}, 
+                                                    {"three", 3}, {"four", 4}};
+    
+    
+    const char* file_name = "htrie_map.data";
+    {
+        serializer serial(file_name);
+        map.serialize(serial);
+    }
+    
+    {
+        deserializer dserial(file_name);
+        auto map_deserialized = tsl::htrie_map<char, std::int64_t>::deserialize(dserial);
+        
+        assert(map == map_deserialized);
+    }
+    
+    {
+        deserializer dserial(file_name);
+        
+        /**
+         * If the serialized and deserialized map are hash compatibles (see conditions in API), 
+         * setting the argument to true speed-up the deserialization process as we don't have 
+         * to recalculate the hash of each key. We also know how much space each bucket needs.
+         */
+        const bool hash_compatible = true;
+        auto map_deserialized = 
+            tsl::htrie_map<char, std::int64_t>::deserialize(dserial, hash_compatible);
+        
+        assert(map == map_deserialized);
+    }
+}
+```
+
+##### Serialization with Boost Serialization and compression with zlib
+
+It's possible to use a serialization library to avoid some of the boilerplate if the types to serialize are more complex.
+
+The following example uses Boost Serialization with the Boost zlib compression stream to reduce the size of the resulting serialized file.
+
+
+```c++
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/utility.hpp>
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <tsl/htrie_map.h>
+
+
+template<typename Archive>
+struct serializer {
+    Archive& ar;
+    
+    template<typename T>
+    void operator()(const T& val) { ar & val; }
+    
+    template<typename CharT>
+    void operator()(const CharT* val, std::size_t val_size) {
+        ar.save_binary((void*) val, val_size*sizeof(CharT));
+    }   
+};
+
+template<typename Archive>
+struct deserializer {
+    Archive& ar;
+    
+    template<typename T>
+    T operator()() { T val; ar & val; return val; }
+    
+    template<typename CharT>
+    void operator()(CharT* val_out, std::size_t val_size) {
+        ar.load_binary((void*) val_out, val_size*sizeof(CharT));
+    }  
+};
+
+namespace boost { namespace serialization {
+template<class Archive, class CharT, class T>
+void serialize(Archive & ar, tsl::htrie_map<CharT, T>& map, const unsigned int version) {
+    split_free(ar, map, version); 
+}
+
+template<class Archive, class CharT, class T>
+void save(Archive & ar, const tsl::htrie_map<CharT, T>& map, const unsigned int version) {
+    serializer<Archive> serial{ar};
+    map.serialize(serial);
+}
+
+
+template<class Archive, class CharT, class T>
+void load(Archive & ar, tsl::htrie_map<CharT, T>& map, const unsigned int version) {
+    deserializer<Archive> deserial{ar};
+    map = tsl::htrie_map<CharT, T>::deserialize(deserial);
+}
+}}
+
+
+int main() {
+    const tsl::htrie_map<char, std::int64_t> map = {{"one", 1}, {"two", 2}, 
+                                                    {"three", 3}, {"four", 4}};
+    
+    
+    const char* file_name = "htrie_map.data";
+    {
+        std::ofstream ofs;
+        ofs.exceptions(ofs.badbit | ofs.failbit);
+        ofs.open(file_name, std::ios::binary);
+        
+        boost::iostreams::filtering_ostream fo;
+        fo.push(boost::iostreams::zlib_compressor());
+        fo.push(ofs);
+        
+        boost::archive::binary_oarchive oa(fo);
+        
+        oa << map;
+    }
+    
+    {
+        std::ifstream ifs;
+        ifs.exceptions(ifs.badbit | ifs.failbit | ifs.eofbit);
+        ifs.open(file_name, std::ios::binary);
+        
+        boost::iostreams::filtering_istream fi;
+        fi.push(boost::iostreams::zlib_decompressor());
+        fi.push(ifs);
+        
+        boost::archive::binary_iarchive ia(fi);
+     
+        tsl::htrie_map<char, std::int64_t> map_deserialized;   
+        ia >> map_deserialized;
+        
+        assert(map == map_deserialized);
+    }
+}
+```
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ struct serializer {
     
     template<typename CharT>
     void operator()(const CharT* val, std::size_t val_size) {
-        ar.save_binary((void*) val, val_size*sizeof(CharT));
+        ar.save_binary(reinterpret_cast<const void*>(val), val_size*sizeof(CharT));
     }   
 };
 
@@ -462,7 +462,7 @@ struct deserializer {
     
     template<typename CharT>
     void operator()(CharT* val_out, std::size_t val_size) {
-        ar.load_binary((void*) val_out, val_size*sizeof(CharT));
+        ar.load_binary(reinterpret_cast<void*>(val_out), val_size*sizeof(CharT));
     }  
 };
 

--- a/include/tsl/array-hash/array_map.h
+++ b/include/tsl/array-hash/array_map.h
@@ -765,7 +765,7 @@ public:
      * Serialize the map through the `serializer` parameter.
      * 
      * The `serializer` parameter must be a function object that supports the following calls:
-     *  - `void operator()(const U& value);` where the types `std::uint64_t`, `float` and `T` must be supported for U.
+     *  - `template<typename U> void operator()(const U& value);` where the types `std::uint64_t`, `float` and `T` must be supported for U.
      *  - `void operator()(const CharT* value, std::size_t value_size);`
      * 
      * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, ...) of the types it serializes
@@ -786,7 +786,7 @@ public:
      * If the deserialized hash map type is hash compatible with the serialized map, the deserialization process can be
      * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash (take care of the 32-bits vs 64 bits), 
      * KeyEqual, GrowthPolicy, StoreNullTerminator, KeySizeT and IndexSizeT must behave the same than the ones used on the 
-     * serialized map. Otherwise the behaviour is undefined with `hash_compatible` sets to true, .
+     * serialized map. Otherwise the behaviour is undefined with `hash_compatible` sets to true.
      * 
      * The behaviour is undefined if the type `CharT` and `T` of the `array_map` are not the same as the
      * types used during serialization.

--- a/include/tsl/array-hash/array_set.h
+++ b/include/tsl/array-hash/array_set.h
@@ -578,7 +578,7 @@ public:
      * Serialize the set through the `serializer` parameter.
      * 
      * The `serializer` parameter must be a function object that supports the following calls:
-     *  - `void operator()(const U& value);` where the types `std::uint64_t` and `float` must be supported for U.
+     *  - `template<typename U> void operator()(const U& value);` where the types `std::uint64_t` and `float` must be supported for U.
      *  - `void operator()(const CharT* value, std::size_t value_size);`
      * 
      * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, ...) of the types it serializes
@@ -593,13 +593,13 @@ public:
      * Deserialize a previouly serialized set through the `deserializer` parameter.
      * 
      * The `deserializer` parameter must be a function object that supports the following calls:
-     *  - `template<typename U> U operator()();` where the types `std::uint64_t`, `float` and `T` must be supported for U.
+     *  - `template<typename U> U operator()();` where the types `std::uint64_t` and `float` must be supported for U.
      *  - `void operator()(CharT* value_out, std::size_t value_size);`
      * 
      * If the deserialized hash set type is hash compatible with the serialized set, the deserialization process can be
      * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash (take care of the 32-bits vs 64 bits), 
      * KeyEqual, GrowthPolicy, StoreNullTerminator, KeySizeT and IndexSizeT must behave the same than the ones used on the 
-     * serialized set. Otherwise the behaviour is undefined with `hash_compatible` sets to true, .
+     * serialized set. Otherwise the behaviour is undefined with `hash_compatible` sets to true.
      * 
      * The behaviour is undefined if the type `CharT` of the `array_set` is not the same as the
      * type used during serialization.

--- a/include/tsl/htrie_map.h
+++ b/include/tsl/htrie_map.h
@@ -558,11 +558,41 @@ public:
     /*
      * Other
      */
+    
+    /**
+     * Serialize the map through the `serializer` parameter.
+     * 
+     * The `serializer` parameter must be a function object that supports the following calls:
+     *  - `void operator()(const U& value);` where the types `std::uint64_t`, `float` and `T` must be supported for U.
+     *  - `void operator()(const CharT* value, std::size_t value_size);`
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, ...) of the types it serializes
+     * in the hands of the `Serializer` function object if compatibilty is required.
+     */
     template<class Serializer>
     void serialize(Serializer& serializer) const {
         m_ht.serialize(serializer);
     }
     
+
+    /**
+     * Deserialize a previouly serialized map through the `deserializer` parameter.
+     * 
+     * The `deserializer` parameter must be a function object that supports the following calls:
+     *  - `template<typename U> U operator()();` where the types `std::uint64_t`, `float` and `T` must be supported for U.
+     *  - `void operator()(CharT* value_out, std::size_t value_size);`
+     * 
+     * If the deserialized hash map part of the hat-trie is hash compatible with the serialized map, the deserialization process 
+     * can be sped up by setting `hash_compatible` to true. To be hash compatible, the Hash (take care of the 32-bits vs 64 bits), 
+     * and KeySizeT must behave the same than the ones used in the serialized map. Otherwise the behaviour is undefined 
+     * with `hash_compatible` sets to true.
+     * 
+     * The behaviour is undefined if the type `CharT` and `T` of the `htrie_map` are not the same as the
+     * types used during serialization.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, size of int, ...) of the types it 
+     * deserializes in the hands of the `Deserializer` function object if compatibilty is required.
+     */
     template<class Deserializer>
     static htrie_map deserialize(Deserializer& deserializer, bool hash_compatible = false) {
         htrie_map map;

--- a/include/tsl/htrie_map.h
+++ b/include/tsl/htrie_map.h
@@ -558,6 +558,19 @@ public:
     /*
      * Other
      */
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        m_ht.serialize(serializer);
+    }
+    
+    template<class Deserializer>
+    static htrie_map deserialize(Deserializer& deserializer, bool hash_compatible = false) {
+        htrie_map map;
+        map.m_ht.deserialize(deserializer, hash_compatible);
+
+        return map;
+    }
+    
     friend bool operator==(const htrie_map& lhs, const htrie_map& rhs) {
         if(lhs.size() != rhs.size()) {
             return false;

--- a/include/tsl/htrie_set.h
+++ b/include/tsl/htrie_set.h
@@ -508,11 +508,41 @@ public:
     /*
      * Other
      */
+    
+    /**
+     * Serialize the set through the `serializer` parameter.
+     * 
+     * The `serializer` parameter must be a function object that supports the following calls:
+     *  - `void operator()(const U& value);` where the types `std::uint64_t` and `float` must be supported for U.
+     *  - `void operator()(const CharT* value, std::size_t value_size);`
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, ...) of the types it serializes
+     * in the hands of the `Serializer` function object if compatibilty is required.
+     */
     template<class Serializer>
     void serialize(Serializer& serializer) const {
         m_ht.serialize(serializer);
     }
     
+
+    /**
+     * Deserialize a previouly serialized set through the `deserializer` parameter.
+     * 
+     * The `deserializer` parameter must be a function object that supports the following calls:
+     *  - `template<typename U> U operator()();` where the types `std::uint64_t` and `float` must be supported for U.
+     *  - `void operator()(CharT* value_out, std::size_t value_size);`
+     * 
+     * If the deserialized hash set part of the hat-trie is hash compatible with the serialized set, the deserialization process 
+     * can be sped up by setting `hash_compatible` to true. To be hash compatible, the Hash (take care of the 32-bits vs 64 bits), 
+     * and KeySizeT must behave the same than the ones used in the serialized set. Otherwise the behaviour is undefined 
+     * with `hash_compatible` sets to true.
+     * 
+     * The behaviour is undefined if the type `CharT` of the `htrie_set` is not the same as the
+     * type used during serialization.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, size of int, ...) of the types it 
+     * deserializes in the hands of the `Deserializer` function object if compatibilty is required.
+     */
     template<class Deserializer>
     static htrie_set deserialize(Deserializer& deserializer, bool hash_compatible = false) {
         htrie_set set;

--- a/include/tsl/htrie_set.h
+++ b/include/tsl/htrie_set.h
@@ -508,6 +508,19 @@ public:
     /*
      * Other
      */
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        m_ht.serialize(serializer);
+    }
+    
+    template<class Deserializer>
+    static htrie_set deserialize(Deserializer& deserializer, bool hash_compatible = false) {
+        htrie_set set;
+        set.m_ht.deserialize(deserializer, hash_compatible);
+
+        return set;
+    }
+    
     friend bool operator==(const htrie_set& lhs, const htrie_set& rhs) {
         if(lhs.size() != rhs.size()) {
             return false;

--- a/tests/trie_map_tests.cpp
+++ b/tests/trie_map_tests.cpp
@@ -591,6 +591,98 @@ BOOST_AUTO_TEST_CASE(test_swap) {
 }
 
 /**
+ * serialize and deserialize
+ */
+BOOST_AUTO_TEST_CASE(test_serialize_desearialize_empty_map) {
+    // serialize empty map; deserialize in new map; check equal.
+    // for deserialization, test it with and without hash compatibility.
+    const tsl::htrie_map<char, move_only_test> empty_map;
+    
+    
+    serializer serial;
+    empty_map.serialize(serial);
+
+    deserializer dserial(serial.str());
+    auto empty_map_deserialized = decltype(empty_map)::deserialize(dserial, true);
+    BOOST_CHECK(empty_map_deserialized == empty_map);
+
+    deserializer dserial2(serial.str());
+    empty_map_deserialized = decltype(empty_map)::deserialize(dserial2, false);
+    BOOST_CHECK(empty_map_deserialized == empty_map);
+}
+
+BOOST_AUTO_TEST_CASE(test_serialize_desearialize_map) {
+    // insert x values; delete some values; serialize map; deserialize in new map; check equal.
+    // for deserialization, test it with and without hash compatibility.
+    const std::size_t nb_values = 1000;
+
+    
+    tsl::htrie_map<char, move_only_test> map(7);
+    
+    map.insert("", utils::get_value<move_only_test>(0));
+    for(std::size_t i = 1; i < nb_values + 40; i++) {
+        map.insert(utils::get_key<char>(i), utils::get_value<move_only_test>(i));
+    }
+
+    for(std::size_t i = nb_values; i < nb_values + 40; i++) {
+        map.erase(utils::get_key<char>(i));
+    }
+    BOOST_CHECK_EQUAL(map.size(), nb_values);
+
+    
+    
+    serializer serial;
+    map.serialize(serial);
+
+    deserializer dserial(serial.str());
+    auto map_deserialized = decltype(map)::deserialize(dserial, true);
+    BOOST_CHECK(map == map_deserialized);
+
+    deserializer dserial2(serial.str());
+    map_deserialized = decltype(map)::deserialize(dserial2, false);
+    BOOST_CHECK(map_deserialized == map);
+}
+
+BOOST_AUTO_TEST_CASE(test_serialize_desearialize_with_different_hash) {
+    // insert x values; delete some values; serialize map; deserialize it in a new map with an incompatible hash; check equal.
+    struct str_hash {
+        std::size_t operator()(const char* key, std::size_t key_size) const {
+            return tsl::ah::str_hash<char>()(key, key_size) + 123;
+        }
+    };
+    
+    
+    const std::size_t nb_values = 1000;
+
+
+    tsl::htrie_map<char, move_only_test> map(7);
+    
+    map.insert("", utils::get_value<move_only_test>(0));
+    for(std::size_t i = 1; i < nb_values + 40; i++) {
+        map.insert(utils::get_key<char>(i), utils::get_value<move_only_test>(i));
+    }
+
+    for(std::size_t i = nb_values; i < nb_values + 40; i++) {
+        map.erase(utils::get_key<char>(i));
+    }
+    BOOST_CHECK_EQUAL(map.size(), nb_values);
+
+    
+    
+    serializer serial;
+    map.serialize(serial);
+
+    deserializer dserial(serial.str());
+    auto map_deserialized = tsl::htrie_map<char, move_only_test, str_hash>::deserialize(dserial);
+    
+    BOOST_CHECK_EQUAL(map.size(), map_deserialized.size());
+    for(auto it = map.cbegin(); it != map.cend(); ++it) {
+        const auto it_element_rhs = map_deserialized.find(it.key());
+        BOOST_CHECK(it_element_rhs != map_deserialized.cend() && it.value() == it_element_rhs.value());
+    }
+}
+
+/**
  * Various operations on empty map
  */
 BOOST_AUTO_TEST_CASE(test_empty_map) {

--- a/tests/trie_map_tests.cpp
+++ b/tests/trie_map_tests.cpp
@@ -682,6 +682,36 @@ BOOST_AUTO_TEST_CASE(test_serialize_desearialize_with_different_hash) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(test_serialize_desearialize_map_no_burst) {
+    // test deserialization when there is only a hash node.
+    // set burst_threshold to x+1; insert x values; serialize map; deserialize in new map; check equal.
+    // for deserialization, test it with and without hash compatibility.
+    const std::size_t nb_values = 100;
+
+    
+    tsl::htrie_map<char, move_only_test> map(nb_values + 1);
+    
+    map.insert("", utils::get_value<move_only_test>(0));
+    for(std::size_t i = 1; i < nb_values; i++) {
+        map.insert(utils::get_key<char>(i), utils::get_value<move_only_test>(i));
+    }
+    
+    BOOST_CHECK_EQUAL(map.size(), nb_values);
+
+    
+    
+    serializer serial;
+    map.serialize(serial);
+
+    deserializer dserial(serial.str());
+    auto map_deserialized = decltype(map)::deserialize(dserial, true);
+    BOOST_CHECK(map == map_deserialized);
+
+    deserializer dserial2(serial.str());
+    map_deserialized = decltype(map)::deserialize(dserial2, false);
+    BOOST_CHECK(map_deserialized == map);
+}
+
 /**
  * Various operations on empty map
  */

--- a/tests/trie_set_tests.cpp
+++ b/tests/trie_set_tests.cpp
@@ -102,4 +102,39 @@ BOOST_AUTO_TEST_CASE(test_move_operator) {
     BOOST_CHECK(set2 == (tsl::htrie_set<char>{"test1"}));
 }
 
+/**
+ * serialize and deserialize
+ */
+BOOST_AUTO_TEST_CASE(test_serialize_desearialize) {
+    // insert x values; delete some values; serialize set; deserialize in new set; check equal.
+    // for deserialization, test it with and without hash compatibility.
+    const std::size_t nb_values = 1000;
+
+    
+    tsl::htrie_set<char> set(0);
+    
+    set.insert("");
+    for(std::size_t i = 1; i < nb_values + 40; i++) {
+        set.insert(utils::get_key<char>(i));
+    }
+
+    for(std::size_t i = nb_values; i < nb_values + 40; i++) {
+        set.erase(utils::get_key<char>(i));
+    }
+    BOOST_CHECK_EQUAL(set.size(), nb_values);
+
+    
+    
+    serializer serial;
+    set.serialize(serial);
+
+    deserializer dserial(serial.str());
+    auto set_deserialized = decltype(set)::deserialize(dserial, true);
+    BOOST_CHECK(set_deserialized == set);
+
+    deserializer dserial2(serial.str());
+    set_deserialized = decltype(set)::deserialize(dserial2, false);
+    BOOST_CHECK(set_deserialized == set);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds two new methods `template<class Serializer> void serialize(Serializer& serializer) const;` and `template<class Deserializer> static array_map deserialize(Deserializer& deserializer, bool hash_compatible = false);` to `tsl::htrie_map/set`. 

They take advantage of the internals of the data structure to provide an efficient way to serialize/deserialize the structure.