### PR TITLE
Detect _MSVC_LANG in addition to __cplusplus

### DIFF
--- a/include/tsl/htrie_hash.h
+++ b/include/tsl/htrie_hash.h
@@ -48,7 +48,7 @@
  * version.
  */
 #ifdef __has_include
-#if __has_include(<string_view>) && __cplusplus >= 201703L
+#if __has_include(<string_view>) && (__cplusplus >= 201703L || _MSVC_LANG >= 201703L)
 #define TSL_HT_HAS_STRING_VIEW
 #endif
 #endif


### PR DESCRIPTION
Addressing issue https://github.com/Tessil/hat-trie/issues/34 ...

With this change, a stock Visual Studio C++17 project will register support for string_view as expected.