### PR TITLE
Add for_each_prefix_of methods to obtain path to longest prefix

### DIFF
--- a/include/tsl/htrie_map.h
+++ b/include/tsl/htrie_map.h
@@ -551,6 +551,100 @@ class htrie_map {
   }
 #endif
 
+  /**
+   * Invoke the given `visitor` function for each element in the trie which is
+   * a prefix of `key`.
+   *
+   * @tparam F Callable target taking a single `iterator` or `const_iterator`
+   *         argument.
+   *
+   * Example:
+   *
+   *     tsl::htrie_map<char, int> map = {{"/foo", 1}, {"/foo/bar", 2}};
+   *     auto print = [](tsl::htrie_map<char>::iterator it) {
+   *        std::cout << it.key() << "\n";
+   *     };
+   *
+   *     map.for_each_prefix_of("/foo", print); // prints "/foo"
+   *     map.for_each_prefix_of("/foo/baz"); // prints nothing
+   *     map.for_each_prefix_of("/foo/bar/baz"); // prints nothing
+   *     map.for_each_prefix_of("/foo/bar/"); // prints "/foo" and "/foo/bar"
+   *     map.for_each_prefix_of("/bar"); // prints nothing
+   *     map.for_each_prefix_of(""); // prints nothing
+   */
+  template <typename F>
+  void for_each_prefix_of_ks(const CharT* key, size_type key_size,
+                             F&& visitor) {
+    return m_ht.for_each_prefix_of(key, key_size, std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of_ks(const CharT* key, size_type key_size,
+                             F&& visitor) const {
+    return m_ht.for_each_prefix_of(key, key_size, std::forward<F>(visitor));
+  }
+#ifdef TSL_HT_HAS_STRING_VIEW
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const std::basic_string_view<CharT>& key,
+                          F&& visitor) {
+    return m_ht.for_each_prefix_of(key.data(), key.size(),
+                                   std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(
+      const std::basic_string_view<CharT>& key, F&& visitor) const {
+    return m_ht.for_each_prefix_of(key.data(), key.size(),
+                                   std::forward<F>(visitor));
+  }
+#else
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const CharT* key, F&& visitor) {
+    return m_ht.for_each_prefix_of(key, std::strlen(key),
+                                   std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const CharT* key, F&& visitor) const {
+    return m_ht.for_each_prefix_of(key, std::strlen(key),
+                                   std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const std::basic_string<CharT>& key, F&& visitor) {
+    return m_ht.for_each_prefix_of(key.data(), key.size(),
+                                   std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const std::basic_string<CharT>& key,
+                          F&& visitor) const {
+    return m_ht.for_each_prefix_of(key.data(), key.size(),
+                                   std::forward<F>(visitor));
+  }
+#endif
+
   /*
    *  Hash policy
    */

--- a/include/tsl/htrie_set.h
+++ b/include/tsl/htrie_set.h
@@ -473,6 +473,100 @@ class htrie_set {
   }
 #endif
 
+  /**
+   * Invoke the given `visitor` function for each element in the trie which is
+   * a prefix of `key`.
+   *
+   * @tparam F Callable target taking a single `iterator` or `const_iterator`
+   *         argument.
+   *
+   * Example:
+   *
+   *     tsl::htrie_set<char> set = {"/foo", "/foo/bar"};
+   *     auto print = [](tsl::htrie_set<char>::iterator it) {
+   *        std::cout << it.key() << "\n";
+   *     };
+   *
+   *     set.for_each_prefix_of("/foo", print); // prints "/foo"
+   *     set.for_each_prefix_of("/foo/baz"); // prints nothing
+   *     set.for_each_prefix_of("/foo/bar/baz"); // prints nothing
+   *     set.for_each_prefix_of("/foo/bar/"); // prints "/foo" and "/foo/bar"
+   *     set.for_each_prefix_of("/bar"); // prints nothing
+   *     set.for_each_prefix_of(""); // prints nothing
+   */
+  template <typename F>
+  void for_each_prefix_of_ks(const CharT* key, size_type key_size,
+                             F&& visitor) {
+    return m_ht.for_each_prefix_of(key, key_size, std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of_ks(const CharT* key, size_type key_size,
+                             F&& visitor) const {
+    return m_ht.for_each_prefix_of(key, key_size, std::forward<F>(visitor));
+  }
+#ifdef TSL_HT_HAS_STRING_VIEW
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const std::basic_string_view<CharT>& key,
+                          F&& visitor) {
+    return m_ht.for_each_prefix_of(key.data(), key.size(),
+                                   std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(
+      const std::basic_string_view<CharT>& key, F&& visitor) const {
+    return m_ht.for_each_prefix_of(key.data(), key.size(),
+                                   std::forward<F>(visitor));
+  }
+#else
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const CharT* key, F&& visitor) {
+    return m_ht.for_each_prefix_of(key, std::strlen(key),
+                                   std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const CharT* key, F&& visitor) const {
+    return m_ht.for_each_prefix_of(key, std::strlen(key),
+                                   std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const std::basic_string<CharT>& key, F&& visitor) {
+    return m_ht.for_each_prefix_of(key.data(), key.size(),
+                                   std::forward<F>(visitor));
+  }
+
+  /**
+   * @copydoc for_each_prefix_of_ks(const CharT*, size_type, F&&)
+   */
+  template <typename F>
+  void for_each_prefix_of(const std::basic_string<CharT>& key,
+                          F&& visitor) const {
+    return m_ht.for_each_prefix_of(key.data(), key.size(),
+                                   std::forward<F>(visitor));
+  }
+#endif
+
   /*
    *  Hash policy
    */

--- a/tests/trie_map_tests.cpp
+++ b/tests/trie_map_tests.cpp
@@ -360,6 +360,49 @@ BOOST_AUTO_TEST_CASE(test_longest_prefix) {
 }
 
 /**
+ * for_each_prefix_of
+ */
+BOOST_AUTO_TEST_CASE(test_for_each_prefix_of) {
+  using map_type = tsl::htrie_map<char, int>;
+  using path_type = std::vector<std::string>;
+
+  map_type map(4);
+  map = {{"a", 1},      {"aa", 1},      {"aaa", 1},   {"aaaaa", 1},
+         {"aaaaaa", 1}, {"aaaaaaa", 1}, {"ab", 1},    {"abcde", 1},
+         {"abcdf", 1},  {"abcdg", 1},   {"abcdh", 1}, {"babc", 1}};
+
+  std::vector<std::pair<const char*, path_type>> test_vectors = {
+    {"a",       {"a"}},
+    {"aa",      {"a", "aa"}},
+    {"aaa",     {"a", "aa", "aaa"}},
+    {"aaaa",    {"a", "aa", "aaa"}},
+    {"ab",      {"a", "ab"}},
+    {"abc",     {"a", "ab"}},
+    {"abcd",    {"a", "ab"}},
+    {"abcdz",   {"a", "ab"}},
+    {"abcde",   {"a", "ab", "abcde"}},
+    {"abcdef",  {"a", "ab", "abcde"}},
+    {"abcdefg", {"a", "ab", "abcde"}},
+    {"dabc",    {}},
+    {"b",       {}},
+    {"bab",     {}},
+    {"babd",    {}},
+    {"",        {}},
+  };
+
+  for (const auto& v: test_vectors) {
+    path_type p;
+    const path_type& expected = v.second;
+    auto visitor = [&p](map_type::const_iterator it) {p.push_back(it.key());};
+    map.for_each_prefix_of(v.first, visitor);
+    BOOST_CHECK_EQUAL_COLLECTIONS(p.begin(), p.end(),
+                                  expected.begin(), expected.end());
+    if (p != expected)
+      BOOST_TEST_MESSAGE("...for test vector input '" << v.first << "'");
+  }
+}
+
+/**
  * erase_prefix
  */
 BOOST_AUTO_TEST_CASE(test_erase_prefix) {


### PR DESCRIPTION
This adds a `for_each_prefix_of` member function in `htrie_map` and `htrie_set` which calls a visitor for each element that is a prefix the given key, fulfilling the feature request #32 proposed by @gh-andre .

I had difficulty coming up with a good concise name, and I would be happy to replace `for_each_prefix_of` with something better.

Unfortunately, the current iterator design doesn't lend itself well to extension for other traversal algorithms. It was far simpler for me to adapt `longest_prefix` so that it calls a handler function for each match along the path to the longest prefix.

Some other trie implementations provide a "cursor" interface and this library could benefit from one as well. It would allow extensibility to implement different types of traversal algorithms without having to modify `htrie_map` and `htrie_set`. IMHO, there should only be one iterator type that traverses all elements so that `htrie_map` and `htrie_set` meet the requirements of a C++ container. All other traversal algorithms should be implemented as free functions (or helper classes) which use the cursor interface.