### PR TITLE
Fix code example of `for_each_prefix_of` in comment

### DIFF
--- a/include/tsl/htrie_map.h
+++ b/include/tsl/htrie_map.h
@@ -561,16 +561,16 @@ class htrie_map {
    * Example:
    *
    *     tsl::htrie_map<char, int> map = {{"/foo", 1}, {"/foo/bar", 2}};
-   *     auto print = [](tsl::htrie_map<char>::iterator it) {
+   *     auto print = [](tsl::htrie_map<char, int>::iterator it) {
    *        std::cout << it.key() << "\n";
    *     };
    *
    *     map.for_each_prefix_of("/foo", print); // prints "/foo"
-   *     map.for_each_prefix_of("/foo/baz"); // prints nothing
-   *     map.for_each_prefix_of("/foo/bar/baz"); // prints nothing
-   *     map.for_each_prefix_of("/foo/bar/"); // prints "/foo" and "/foo/bar"
-   *     map.for_each_prefix_of("/bar"); // prints nothing
-   *     map.for_each_prefix_of(""); // prints nothing
+   *     map.for_each_prefix_of("/foo/baz", print); // prints "/foo"
+   *     map.for_each_prefix_of("/foo/bar/baz", print); // prints "/foo" and "/foo/bar"
+   *     map.for_each_prefix_of("/foo/bar/", print); // prints "/foo" and "/foo/bar"
+   *     map.for_each_prefix_of("/bar", print); // prints nothing
+   *     map.for_each_prefix_of("", print); // prints nothing
    */
   template <typename F>
   void for_each_prefix_of_ks(const CharT* key, size_type key_size,

--- a/include/tsl/htrie_set.h
+++ b/include/tsl/htrie_set.h
@@ -488,11 +488,11 @@ class htrie_set {
    *     };
    *
    *     set.for_each_prefix_of("/foo", print); // prints "/foo"
-   *     set.for_each_prefix_of("/foo/baz"); // prints nothing
-   *     set.for_each_prefix_of("/foo/bar/baz"); // prints nothing
-   *     set.for_each_prefix_of("/foo/bar/"); // prints "/foo" and "/foo/bar"
-   *     set.for_each_prefix_of("/bar"); // prints nothing
-   *     set.for_each_prefix_of(""); // prints nothing
+   *     set.for_each_prefix_of("/foo/baz", print); // prints "/foo"
+   *     set.for_each_prefix_of("/foo/bar/baz", print); // prints "/foo" and "/foo/bar"
+   *     set.for_each_prefix_of("/foo/bar/", print); // prints "/foo" and "/foo/bar"
+   *     set.for_each_prefix_of("/bar", print); // prints nothing
+   *     set.for_each_prefix_of("", print); // prints nothing
    */
   template <typename F>
   void for_each_prefix_of_ks(const CharT* key, size_type key_size,


### PR DESCRIPTION
The example of `for_each_prefix_of` gave some wrong results, which can be confusing for users.

This PR fixed them.